### PR TITLE
Created a Windows build script in powershell

### DIFF
--- a/brainwallet/phrases.py
+++ b/brainwallet/phrases.py
@@ -32,7 +32,7 @@ class Phrases:
 
     @classmethod
     def _getFilename(cls,language):
-        filename = "%s/%s.txt" % (cls._getDirectory(), language)
+        filename =  os.path.join(cls._getDirectory(), "%s.txt" % (language))
         return filename
 
     @classmethod

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -1,0 +1,31 @@
+# Build a zipped windows release of brainwallet
+# For this script to work properly, the build system needs to be Windows 10(with Powershell >= v5.0) and have python installed
+# If Powershell complains about being unable to execute scripts, open an administrative powershell terminal, navigate to the cloned repo, and run "Unblock-File -Path .\build_windows.ps1"
+
+# Variables: Change these to your installed python version of choice and the name for the zip file
+$PYTHON_VERSION="Python36"
+$Release_Name="brainwallet"
+
+cd $PSScriptRoot\brainwallet
+
+# The python "scripts" directory and Windows 10 DLLs directory needed to be added to the PATH for pyinstaller to build properly on my machine
+$env:PATH="$env:PATH%;$env:LocalAppData\Programs\Python\$PYTHON_VERSION\Scripts;C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\x64"
+
+# Test if pyinstaller is installed and install it if not
+pyinstaller --version > $null
+
+if (-Not ($?)) {
+    py -m pip install pyinstaller
+}
+
+# Generate a Windows distribution
+pyinstaller brainwallet.py -y
+
+# Copy the wordlist into the brainwallet distribution directory
+Copy-Item -recurse "wordlist" -Destination "dist\brainwallet\wordlist"
+
+# Make a zip in the root of the repo with the desired name
+Compress-Archive -Path ".\dist\brainwallet\*" -CompressionLevel Optimal -DestinationPath "..\$Release_Name" -Force
+
+# Clean up remaining junk files from pyinstaller
+Remove-Item 'dist','build','brainwallet.spec' -Force -Recurse


### PR DESCRIPTION
This uses a Python application called pyinstaller to make a folder containing a Windows binary and all required dependencies. It then makes a zip of the folder and places it in the root of the repo. The Powershell script requires Windows 10, Powershell >= v5.0 and some version of Python installed (preferably 3.6). The resulting executable does not require python to be installed to run.

The reading code in phrases.py was unix specific (it used forward-slash), so I generalized it using os.path.join.

It doesn't include any way to run the unit tests yet.

Closes #9 